### PR TITLE
id requires string only

### DIFF
--- a/sdf.go
+++ b/sdf.go
@@ -1,7 +1,6 @@
 package s32cs
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"regexp"
@@ -11,7 +10,7 @@ import (
 var InvalidChars = regexp.MustCompile("[^\u0009\u000a\u000d\u0020-\uD7FF\uE000-\uFFFD]")
 
 type SDFRecord struct {
-	ID     json.Number            `json:"id"`
+	ID     string                 `json:"id"`
 	Type   string                 `json:"type"`
 	Fields map[string]interface{} `json:"fields,omitempty"`
 }

--- a/sdf_test.go
+++ b/sdf_test.go
@@ -19,9 +19,9 @@ var sdfs = []struct {
 		Expect: []byte(`{"id":"123","type":"add","fields":{"foo":"bar","bar":["A","B"]}}`),
 	},
 	{
-		Name:   "add_integer_id",
-		Src:    []byte(`{"id":123,"type":"add","fields":{"foo":"bar","bar":["A","B"]}}`),
-		Expect: []byte(`{"id":"123","type":"add","fields":{"foo":"bar","bar":["A","B"]}}`),
+		Name:   "add2",
+		Src:    []byte(`{"id":"xxx123","type":"add","fields":{"foo":"bar","bar":["A","B"]}}`),
+		Expect: []byte(`{"id":"xxx123","type":"add","fields":{"foo":"bar","bar":["A","B"]}}`),
 	},
 	{
 		Name:   "delete",


### PR DESCRIPTION
SDF spec requires string type only.
Reverts https://github.com/fujiwara/s32cs/pull/5.